### PR TITLE
Adding dropdowns for cow characteristics

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,11 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
 linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at https://dart.dev/lints.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+    avoid_print: false
+    prefer_const_constructors_in_immutables: false
+    prefer_const_constructors: false
+    prefer_const_literals_to_create_immutables: false
+    prefer_final_fields: false
+    unnecessary_breaks: true
+    use_key_in_widget_constructors: false

--- a/lib/constants/cow_characteristics_constants.dart
+++ b/lib/constants/cow_characteristics_constants.dart
@@ -1,0 +1,90 @@
+class CowCharacteristicsConstants {
+  static const List<String> liveWeightOptions = [
+    'Choose live weight (kg)',
+    '100',
+    '125',
+    '150',
+    '175',
+    '200',
+    '225',
+    '250',
+    '275',
+    '300',
+    '325',
+    '350',
+    '375',
+    '400',
+    '425',
+    '450',
+    '475',
+    '500',
+    '525',
+    '550',
+    '575',
+    '600'
+  ];
+
+  static const List<String> pregnancyOptions = [
+    'Choose pregnancy month',
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9'
+  ];
+
+  static const List<String> milkFatOptions = [
+    'Choose milk fat %',
+    '3.0',
+    '3.1',
+    '3.2',
+    '3.3',
+    '3.4',
+    '3.5',
+    '3.6',
+    '3.7',
+    '3.8',
+    '3.9',
+    '4.0',
+    '4.1',
+    '4.2',
+    '4.3',
+    '4.4',
+    '4.5',
+    '4.6',
+    '4.7',
+    '4.8',
+    '4.9',
+    '5.0',
+    '5.1',
+    '5.2'
+  ];
+
+  static const List<String> milkProteinOptions = [
+    'Choose milk protein %',
+    '2.6',
+    '2.7',
+    '2.8',
+    '2.9',
+    '3.0',
+    '3.1',
+    '3.2',
+    '3.3',
+    '3.4',
+    '3.5',
+    '3.6'
+  ];
+
+  static const List<String> lactationOptions = [
+    'Choose lactation stage',
+    'Dry',
+    'Early lactation',
+    'Mid lactation',
+    'Late lactation'
+  ];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,5 @@
 import 'package:flutter/material.dart';
-import 'screens/home_page.dart';
-import 'screens/ration_formulation_page.dart';
-import 'screens/budget_tool_page.dart';
-import 'screens/feeding_guidelines_page.dart';
-import 'screens/cow_requirements_page.dart';
-import 'screens/feed_formula_page.dart';
-import 'screens/feed_formula_results_page.dart';
+import 'screens/cow_characteristics_page.dart';
 
 void main() {
   runApp(RationCalculatorApp());
@@ -17,15 +11,7 @@ class RationCalculatorApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: HomePage(),
-      routes: {
-        '/rationFormulation': (context) => RationFormulationPage(),
-        '/budgetTool': (context) => BudgetToolPage(),
-        '/feedingGuidelines': (context) => FeedingGuidelinesPage(),
-        '/cowRequirements': (context) => CowRequirementsPage(),
-        '/feedFormula': (context) => FeedFormulaPage(),
-        '/feedFormulaResults': (context) => FeedFormulaResultsPage(),
-      },
+      home: CowCharacteristicsPage(),
     );
   }
 }

--- a/lib/screens/cow_characteristics_page.dart
+++ b/lib/screens/cow_characteristics_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../widgets/custom_text_field.dart';
+import '../widgets/custom_dropdown_field.dart';
 import '../models/cow_characteristics_model.dart';
+import '../constants/cow_characteristics_constants.dart';
 
 class CowCharacteristicsPage extends StatefulWidget {
   const CowCharacteristicsPage({super.key});
@@ -20,12 +22,12 @@ class _CowCharacteristicsPageState extends State<CowCharacteristicsPage> {
   @override
   void initState() {
     super.initState();
-    liveWeightController.text = '500';
-    pregnancyController.text = '3';
-    volumeController.text = '20';
-    milkFatController.text = '4.0';
-    milkProteinController.text = '3.2';
-    lactationController.text = 'Early lactation';
+    liveWeightController.text = 'Choose live weight (kg)';
+    pregnancyController.text = 'Choose pregnancy month';
+    volumeController.text = '';
+    milkFatController.text = 'Choose milk fat %';
+    milkProteinController.text = 'Choose milk protein %';
+    lactationController.text = 'Choose lactation stage';
   }
 
   @override
@@ -47,27 +49,70 @@ class _CowCharacteristicsPageState extends State<CowCharacteristicsPage> {
         padding: const EdgeInsets.all(16.0),
         child: ListView(
           children: [
-            const ListTile(
+            ListTile(
               leading: Icon(Icons.pets, size: 40),
               title: Text('Cow Characteristics',
                   style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
               subtitle: Text('Milk Yield', style: TextStyle(fontSize: 18)),
             ),
-            const SizedBox(height: 20),
-            CustomTextField(
-                labelText: 'Live weight (kg)',
-                controller: liveWeightController),
-            CustomTextField(
-                labelText: 'Pregnancy (mth)', controller: pregnancyController),
+            SizedBox(height: 20),
+            CustomDropdownField(
+              hintText: liveWeightController.text,
+              options: CowCharacteristicsConstants.liveWeightOptions,
+              onChanged: (value) {
+                setState(() {
+                  liveWeightController.text = value ?? '';
+                });
+              },
+              value: liveWeightController.text,
+              labelText: 'Live weight (kg)',
+            ),
+            CustomDropdownField(
+              hintText: pregnancyController.text,
+              options: CowCharacteristicsConstants.pregnancyOptions,
+              onChanged: (value) {
+                setState(() {
+                  pregnancyController.text = value ?? '';
+                });
+              },
+              value: pregnancyController.text,
+              labelText: 'Pregnancy (mth)',
+            ),
             CustomTextField(
                 labelText: 'Volume (kg)', controller: volumeController),
-            CustomTextField(
-                labelText: 'Milk fat (%)', controller: milkFatController),
-            CustomTextField(
-                labelText: 'Milk protein (%)',
-                controller: milkProteinController),
-            CustomTextField(
-                labelText: 'Lactation stage', controller: lactationController),
+            CustomDropdownField(
+              hintText: milkFatController.text,
+              options: CowCharacteristicsConstants.milkFatOptions,
+              onChanged: (value) {
+                setState(() {
+                  milkFatController.text = value ?? '';
+                });
+              },
+              value: milkFatController.text,
+              labelText: 'Milk fat (%)',
+            ),
+            CustomDropdownField(
+              hintText: milkProteinController.text,
+              options: CowCharacteristicsConstants.milkProteinOptions,
+              onChanged: (value) {
+                setState(() {
+                  milkProteinController.text = value ?? '';
+                });
+              },
+              value: milkProteinController.text,
+              labelText: 'Milk protein (%)',
+            ),
+            CustomDropdownField(
+              hintText: lactationController.text,
+              options: CowCharacteristicsConstants.lactationOptions,
+              onChanged: (value) {
+                setState(() {
+                  lactationController.text = value ?? '';
+                });
+              },
+              value: lactationController.text,
+              labelText: 'Lactation stage',
+            ),
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: calculateCowRequirements,

--- a/lib/widgets/custom_dropdown_field.dart
+++ b/lib/widgets/custom_dropdown_field.dart
@@ -32,7 +32,7 @@ class CustomDropdownField extends StatelessWidget {
         items: options.map((String value) {
           return DropdownMenuItem<String>(
             value: value,
-            child: Text(value.toString()),
+            child: Text(value),
           );
         }).toList(),
         onChanged: onChanged,

--- a/lib/widgets/custom_dropdown_field.dart
+++ b/lib/widgets/custom_dropdown_field.dart
@@ -5,12 +5,14 @@ class CustomDropdownField extends StatelessWidget {
   final List<String> options;
   final ValueChanged<String?> onChanged;
   final String? value;
+  final String? labelText;
 
   CustomDropdownField(
       {required this.hintText,
       required this.options,
       required this.onChanged,
-      this.value});
+      this.value,
+      this.labelText});
 
   @override
   Widget build(BuildContext context) {
@@ -21,6 +23,7 @@ class CustomDropdownField extends StatelessWidget {
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(8.0),
           ),
+          labelText: labelText,
           filled: true,
           fillColor: Colors.white,
         ),
@@ -29,7 +32,7 @@ class CustomDropdownField extends StatelessWidget {
         items: options.map((String value) {
           return DropdownMenuItem<String>(
             value: value,
-            child: Text(value),
+            child: Text(value.toString()),
           );
         }).toList(),
         onChanged: onChanged,

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rationapp/main.dart'; // Replace with your actual import
 


### PR DESCRIPTION
Based on the calculations in the Feed calculator spreadsheet, the Live weight (kg), Pregnancy (mth), Milk fat (%), Milk protein (%), and Lactation stage entries are dropdowns. The cow requirements are calculated by finding exact matches in a lookup table using the inputted values. I've made edits to the Cow Characteristics page to have the dropdowns.

https://github.com/user-attachments/assets/49eb8ec5-e341-4f41-b1f9-99f16b08d57e

I've also set the app's entry point to the cow characteristics page. From our last meeting, the expected flow should be:
1. Enter cow characteristics
2. Calculate and show cow requirements
3. Direct user to enter fodder and concentrate
4. Show the feed formula for the entered food and whether or not it meets the requirements

My immediate next step is implementing the cow requirements calculation.